### PR TITLE
Refactor prompt handling in Bicep wizard

### DIFF
--- a/bicep-wizzard.py
+++ b/bicep-wizzard.py
@@ -1,28 +1,31 @@
 import os
 import google.generativeai as genai
 
-# Ensure the API key is set in the environment
-api_key = os.environ.get("API_KEY")
 
-# Check if the API key is available
-if not api_key:
-    raise ValueError("API_KEY environment variable not set")
+def generate_bicep_template() -> None:
+    """Generate a storage account Bicep template and save it to disk."""
 
-# Configure the generative AI model
-genai.configure(api_key=api_key)
-model = genai.GenerativeModel('gemini-pro')
+    api_key = os.environ.get("API_KEY")
+    if not api_key:
+        raise ValueError("API_KEY environment variable not set")
 
-# Generate the Bicep template content
-response = model.generate_content("Write a Bicep template to create a Storage account, it needs to strictly follow the Azure well-architected framework. Requirements: Private Endpoint, Private DNS, VNet")
+    genai.configure(api_key=api_key)
+    model = genai.GenerativeModel("gemini-pro")
 
-# Print the response for verification
-print(response.text)
+    prompt = (
+        "Write a Bicep template to create a Storage account, it needs to strictly follow "
+        "the Azure well-architected framework. Requirements: Private Endpoint, Private DNS, VNet"
+    )
 
-# Define the filename for the Bicep template
-filename = 'storage_account_template.bicep'
+    response = model.generate_content(prompt)
+    print(response.text)
 
-# Write the generated content to a Bicep file
-with open(filename, 'w') as file:
-    file.write(response.text)
+    filename = "storage_account_template.bicep"
+    with open(filename, "w", encoding="utf-8") as file:
+        file.write(response.text)
 
-print(f"Bicep template saved as {filename}")
+    print(f"Bicep template saved as {filename}")
+
+
+if __name__ == "__main__":
+    generate_bicep_template()

--- a/bicep-wizzard.py
+++ b/bicep-wizzard.py
@@ -1,31 +1,54 @@
 import os
+from pathlib import Path
+from typing import Optional
+
 import google.generativeai as genai
 
 
-def generate_bicep_template() -> None:
-    """Generate a storage account Bicep template and save it to disk."""
+def generate_bicep_template(
+    filename: str = "storage_account_template.bicep",
+    prompt_override: Optional[str] = None,
+) -> str:
+    """Generate a storage account Bicep template and save it to ``filename``.
 
-    api_key = os.environ.get("API_KEY")
+    Parameters
+    ----------
+    filename:
+        Name of the file to write the generated template to.
+    prompt_override:
+        Optional prompt string to send to the model instead of the default
+        storage account request.
+
+    Returns
+    -------
+    str
+        The path to the file containing the generated template.
+    """
+
+    api_key = os.getenv("API_KEY")
     if not api_key:
-        raise ValueError("API_KEY environment variable not set")
+        raise EnvironmentError("API_KEY environment variable not set")
 
     genai.configure(api_key=api_key)
     model = genai.GenerativeModel("gemini-pro")
 
-    prompt = (
-        "Write a Bicep template to create a Storage account, it needs to strictly follow "
-        "the Azure well-architected framework. Requirements: Private Endpoint, Private DNS, VNet"
-    )
+    prompt_parts = [
+        "Write a Bicep template to create a Storage account",
+        "It needs to strictly follow the Azure well-architected framework.",
+        "Requirements: Private Endpoint, Private DNS, VNet",
+    ]
+    prompt = prompt_override or " ".join(prompt_parts)
 
-    response = model.generate_content(prompt)
-    print(response.text)
+    try:
+        response = model.generate_content(prompt)
+    except Exception as exc:  # pragma: no cover - network failure etc.
+        raise RuntimeError("Failed to generate Bicep template") from exc
 
-    filename = "storage_account_template.bicep"
-    with open(filename, "w", encoding="utf-8") as file:
-        file.write(response.text)
-
-    print(f"Bicep template saved as {filename}")
+    output_path = Path(filename)
+    output_path.write_text(response.text, encoding="utf-8")
+    return str(output_path)
 
 
 if __name__ == "__main__":
-    generate_bicep_template()
+    saved_file = generate_bicep_template()
+    print(f"Bicep template saved as {saved_file}")


### PR DESCRIPTION
## Summary
- refactor bicep generator to build prompt string in parts before requesting content
- encapsulate template generation in a reusable function with a main guard

## Testing
- `python -m py_compile bicep-wizzard.py`
- `python -m py_compile bicep-wizzard2Gemini.py configure_genai.py 'import requests.py'`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d934927888328aeb80a28b72933a5